### PR TITLE
Camera pitch

### DIFF
--- a/src/modules/video/Camera.cpp
+++ b/src/modules/video/Camera.cpp
@@ -61,6 +61,16 @@ void Camera::rotate(const glm::vec3& radians) {
 	}
 }
 
+void Camera::pitch(float radians) {
+	if (_type == CameraType::FirstPerson) {
+		const float curpitch = glm::pitch(_quat);
+		if (glm::abs(curpitch + radians) >= MAX_PITCH) {
+			radians = copysign(MAX_PITCH, curpitch) - curpitch;
+		}
+	}
+	rotate(radians, glm::right);
+}
+
 inline void Camera::slerp(const glm::quat& quat, float factor) {
 	_quat = glm::mix(_quat, quat, factor);
 	_dirty |= DIRTY_ORIENTATION;
@@ -392,5 +402,6 @@ void Camera::setFarPlane(float farPlane) {
 	_dirty |= DIRTY_PERSPECTIVE;
 	_farPlane = farPlane;
 }
+
 
 }

--- a/src/modules/video/Camera.h
+++ b/src/modules/video/Camera.h
@@ -51,6 +51,8 @@ protected:
 
 	constexpr static uint32_t DIRTY_ALL = ~0u;
 
+	constexpr static float MAX_PITCH = glm::half_pi<float>() - 0.01f;
+
 	inline bool isDirty(uint32_t flag) const {
 		return (_dirty & flag) != 0u;
 	}
@@ -326,10 +328,6 @@ inline float Camera::roll() const {
 
 inline float Camera::yaw() const {
 	return glm::yaw(_quat);
-}
-
-inline void Camera::pitch(float radians) {
-	rotate(radians, glm::right);
 }
 
 inline void Camera::yaw(float radians) {

--- a/src/tools/mapview/MapView.cpp
+++ b/src/tools/mapview/MapView.cpp
@@ -320,8 +320,8 @@ core::AppState MapView::onRunning() {
 	const bool current = isRelativeMouseMode();
 	if (current) {
 		_camera.rotate(glm::vec3(_mouseRelativePos.y, _mouseRelativePos.x, 0.0f) * _rotationSpeed->floatVal());
+		_entity->setOrientation(-1.0 * _camera.yaw());
 	}
-
 	_axis.render(_camera);
 	_entity->update(_deltaFrameMillis);
 	return state;

--- a/src/tools/mapview/PlayerMovement.cpp
+++ b/src/tools/mapview/PlayerMovement.cpp
@@ -6,6 +6,7 @@
 #include "core/command/Command.h"
 #include "voxel/Constants.h"
 
+
 namespace frontend {
 
 void PlayerMovement::construct() {
@@ -20,8 +21,9 @@ void PlayerMovement::shutdown() {
 }
 
 void PlayerMovement::updatePos(video::Camera& camera, float deltaFrameSeconds, ClientEntityPtr& entity, std::function<int(const glm::vec3& pos)> heightResolver) {
-
 	static const glm::vec3 eye(0.0f, 1.8f, 0.0f);
+	const glm::quat& q = camera.quaternion();
+	const double yaw = -1.0 * glm::yaw(q);
 
 	const attrib::ShadowAttributes& attribs = entity->attrib();
 	const double speed = attribs.current(attrib::Type::SPEED);


### PR DESCRIPTION
- limiting the pitch from bottom (-pi/2) to top (+pi/2)
- shorten camera distance if camera is in the underground (mapview)
- fixed yaw generation for placing and moving the entity (mapview)
- added fixed eyeheight to the targetposition (mapview)
one thing i havent fixed: the renderer gets crazy, if yaw get greater than pi/2. Probably  a problem yaw of entity and camera which differs by a factor of -1